### PR TITLE
Enhance Java 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: java
 jdk:
 - openjdk8
-branches:
-  only:
-  - master
+- openjdk11
 cache:
   directories:
   - $HOME/.m2
-after_success:
-- openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in $GPG_DIR/pubring.gpg.enc
-  -out $GPG_DIR/pubring.gpg -d
-- openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in $GPG_DIR/secring.gpg.enc
-  -out $GPG_DIR/secring.gpg -d
-- $GPG_DIR/publish.sh
-- mvn test jacoco:report
-- mvn coveralls:report
-
+jobs:
+  include:
+    - stage: publish
+      jdk: openjdk8
+      if: branch = master AND type != pull_request AND fork = false
+      script:
+      - openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in $GPG_DIR/pubring.gpg.enc
+        -out $GPG_DIR/pubring.gpg -d
+      - openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in $GPG_DIR/secring.gpg.enc
+        -out $GPG_DIR/secring.gpg -d
+      - $GPG_DIR/publish.sh
+      - mvn test jacoco:report
+      - mvn coveralls:report
 env:
   global:
   - GPG_DIR="`pwd`/deploy"

--- a/lab-base/pom.xml
+++ b/lab-base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.base</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.collections</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lab-collections/pom.xml
+++ b/lab-collections/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.collections</artifactId>

--- a/lab-consistency/pom.xml
+++ b/lab-consistency/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.consistency</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-core/pom.xml
+++ b/lab-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.core</artifactId>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.collections</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-core/src/main/java/com/github/jnthnclt/os/lab/core/io/DirectBufferCleaner.java
+++ b/lab-core/src/main/java/com/github/jnthnclt/os/lab/core/io/DirectBufferCleaner.java
@@ -24,12 +24,13 @@ class DirectBufferCleaner {
         try {
             _directBufferClass = Class.forName("sun.nio.ch.DirectBuffer");
             _directBufferCleanerMethod = _directBufferClass.getMethod("cleaner");
-            _cleanerClass = Class.forName("sun.misc.Cleaner");
+            _cleanerClass = _directBufferCleanerMethod.getReturnType();
             _cleanMethod = _cleanerClass.getMethod("clean");
             _available = true;
         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
-            System.out.println("Failed to reflect direct buffer cleaner, these methods will be unavailable");
-            e.printStackTrace();
+            System.out.println("Failed to reflect direct buffer cleaner, these methods will be unavailable. " +
+                               "If you are on Java 9+ add --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED " +
+                               "to JVM options");
         }
         directBufferClass = _directBufferClass;
         directBufferCleanerMethod = _directBufferCleanerMethod;
@@ -46,8 +47,9 @@ class DirectBufferCleaner {
                     cleanMethod.invoke(cleaner);
                 }
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-                System.out.println("Failed to clean buffer");
-                e.printStackTrace();
+                System.out.println("Failed to clean buffer. " +
+                                   "If you are on Java 9+ add --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED " +
+                                   "to JVM options");
             }
         }
     }

--- a/lab-core/src/test/java/com/github/jnthnclt/os/lab/core/LABValidationNGTest.java
+++ b/lab-core/src/test/java/com/github/jnthnclt/os/lab/core/LABValidationNGTest.java
@@ -325,7 +325,7 @@ public class LABValidationNGTest {
                                 },
                                 (index, key, timestamp, tombstoned, version1, value1) -> {
                                     hits.incrementAndGet();
-                                    found.add(key == null ? 0 : key.getLong(0));
+                                    found.add(key == null ? 0L : key.getLong(0));
                                     return true;
                                 }, true);
                         }

--- a/lab-export/pom.xml
+++ b/lab-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.export</artifactId>

--- a/lab-nn/pom.xml
+++ b/lab-nn/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.nn</artifactId>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.roaring</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lab-order/pom.xml
+++ b/lab-order/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <properties>
         <aws-version>1.11.558</aws-version>
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-roaring/pom.xml
+++ b/lab-roaring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.roaring</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>net.sf.trove4j</groupId>-->

--- a/lab-s3/pom.xml
+++ b/lab-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.11</version>
+        <version>1.11.1-SNAPSHOT</version>
     </parent>
     <properties>
         <aws-version>1.11.558</aws-version>
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.11</version>
+            <version>1.11.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab</artifactId>
-    <version>1.11</version>
+    <version>1.11.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -151,9 +151,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.2.0</version>
                 <executions>
                     <execution>
                         <id>check</id>
@@ -246,7 +246,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -267,7 +267,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -280,7 +280,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
## Overview

This PR adds some minor changes to the library to enhance the way it works with Java 11 (and Java 9+ in general). The baseline is kept at Java 8.

The changes include:

1. Build against both JVM 8 and JVM 11. Publishing is only done with JVM 8. To support this logic, the `after_success` hook is replaced with `publish` [build stage](https://docs.travis-ci.com/user/build-stages). Basic tests now execute for all branches, but `publish` [is limited to](https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-stages) `master` branch builds.
2. Maven plugin updates: plugins are upgraded to their latest versions, unsupported Findbugs plugin is replaced with its successor Spotbugs, Javadoc plugin is tuned so it can build Java 8-style docs even if executed by JVM 11.
3. `DirectBufferCleaner` polish. The return type of `sun.nio.ch.DirectBuffer.cleaner()` has changed from `sun.misc.Cleaner` to `jdk.internal.ref.Cleaner` in JDK 9. It's also not accessible to "normal" code unless JVM is launched with `--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED`.
