### PR TITLE
Upgrade RoaringBitmap from 0.6.47 to 0.9.14 (latest)

### DIFF
--- a/lab-base/pom.xml
+++ b/lab-base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.base</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.collections</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lab-collections/pom.xml
+++ b/lab-collections/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.collections</artifactId>

--- a/lab-consistency/pom.xml
+++ b/lab-consistency/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.consistency</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-core/pom.xml
+++ b/lab-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.core</artifactId>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.collections</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-export/pom.xml
+++ b/lab-export/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.export</artifactId>

--- a/lab-nn/pom.xml
+++ b/lab-nn/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.nn</artifactId>
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.roaring</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lab-order/pom.xml
+++ b/lab-order/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <properties>
         <aws-version>1.11.558</aws-version>
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/lab-roaring/pom.xml
+++ b/lab-roaring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab.roaring</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>net.sf.trove4j</groupId>-->

--- a/lab-roaring/src/main/java/org/roaringbitmap/RoaringUtils.java
+++ b/lab-roaring/src/main/java/org/roaringbitmap/RoaringUtils.java
@@ -29,9 +29,9 @@ public class RoaringUtils {
         int pos1 = 0, pos2 = 0;
 
         while (pos1 < length1 && pos2 < length2) {
-            final short s1 = x1.highLowContainer.getKeyAtIndex(pos1);
-            final short s2 = x2.highLowContainer.getKeyAtIndex(pos2);
-            if (s1 == s2) {
+            final char k1 = x1.highLowContainer.getKeyAtIndex(pos1);
+            final char k2 = x2.highLowContainer.getKeyAtIndex(pos2);
+            if (k1 == k2) {
                 final Container c1 = x1.highLowContainer.getContainerAtIndex(pos1);
                 final Container c2 = x2.highLowContainer.getContainerAtIndex(pos2);
                 final Container c = c1.and(c2);
@@ -40,10 +40,10 @@ public class RoaringUtils {
                 }
                 ++pos1;
                 ++pos2;
-            } else if (Util.compareUnsigned(s1, s2) < 0) { // s1 < s2
-                pos1 = x1.highLowContainer.advanceUntil(s2, pos1);
-            } else { // s1 > s2
-                pos2 = x2.highLowContainer.advanceUntil(s1, pos2);
+            } else if (k1 < k2) {
+                pos1 = x1.highLowContainer.advanceUntil(k2, pos1);
+            } else { // k1 > k2
+                pos2 = x2.highLowContainer.advanceUntil(k1, pos2);
             }
         }
         return false;

--- a/lab-s3/pom.xml
+++ b/lab-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jnthnclt</groupId>
         <artifactId>os.lab</artifactId>
-        <version>1.12.1</version>
+        <version>1.12.2-SNAPSHOT</version>
     </parent>
     <properties>
         <aws-version>1.11.558</aws-version>
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.base</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.jnthnclt</groupId>
             <artifactId>os.lab.core</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jnthnclt</groupId>
     <artifactId>os.lab</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.6.47</version>
+            <version>0.9.14</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
## Overview

This PR upgrades [RoaringBitmap](https://github.com/RoaringBitmap/RoaringBitmap) from  to `0.9.14` (latest at the moment of writing) to pick up all the latest improvements.

The main change  in the Java code is switching from using type `short` to type `char` to adapt to the same change in RoaringBitmap (https://github.com/RoaringBitmap/RoaringBitmap/pull/364) that was [introduced in version `0.8.12`](https://github.com/RoaringBitmap/RoaringBitmap/compare/RoaringBitmap-0.8.11...RoaringBitmap-0.8.12).

This PR does not introduce any changes in public API of the classes. Also, both types (`short` and `char`) are of 2 bytes size, so the serialization/deserialization is backward compatible. So, from the code prospective it would be a patch version bump, but as it requires an upgrade of the RoaringBitmap dependency, I think it's at least minor version bump.